### PR TITLE
Adding histograms with total and pass entries

### DIFF
--- a/python/postprocessing/modules/jme/jetmetUncertainties.py
+++ b/python/postprocessing/modules/jme/jetmetUncertainties.py
@@ -105,6 +105,8 @@ class jetmetUncertaintiesProducer(Module):
             jesUncertainty_label = jesUncertainty
             if self.era == "2016" and jesUncertainty == 'Total' and len(self.jesUncertainties) == 1:
                 jesUncertainty_label = ''
+            if self.era == "2017" and jesUncertainty == 'Total' and len(self.jesUncertainties) == 1:
+                jesUncertainty_label = ''
             pars = ROOT.JetCorrectorParameters(os.path.join(self.jesInputFilePath, self.jesUncertaintyInputFileName),jesUncertainty_label)
             self.jesUncertainty[jesUncertainty] = ROOT.JetCorrectionUncertainty(pars)    
 


### PR DESCRIPTION
Hi,

I modified the event loop to get a histogram in each output root file that has two bins:
* The total number of entries processed.
* The number of entries that passed the selection.
Please consider for merging (possibly not in the master branch, up to you; please ask me if you want this PR to be made elsewhere).

Cheers,
Olivier
